### PR TITLE
Make UDP Associate function meet RFC standard

### DIFF
--- a/ccsocks5/client.go
+++ b/ccsocks5/client.go
@@ -166,6 +166,10 @@ func (sf *Client) handshake(command byte, addr string) (string, error) {
 		}
 	}
 
+	if command == statute.CommandAssociate {
+		addr = sf.proxyConn.LocalAddr().String()
+	}
+	
 	a, err := statute.ParseAddrSpec(addr)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Hi, i happen to use your repo to test my program, and i found that something goes wrong: The UDP Associate function doesn't meet RFC standard prefectly.
The original text of the RFC1928 is:
> The UDP ASSOCIATE request is used to establish an association within the UDP relay process to handle UDP datagrams. The DST.ADDR and DST.PORT fields contain the address and port that the client expects to use to send UDP datagrams on for the association.  The server MAY use this information to limit access to the association.  If the client is not in possesion of the information at the time of the UDP ASSOCIATE, the client MUST use a port number and address of all zeros.

And I found the original implement is to send the target's ip+port combination instead of the one client **expects to use to send UDP datagrams on for the association**
So, i make a little change on your repo, and hope that won't bring any mistakes 😊
Feel free to contact me if you have any problems.
Have a nice day 👋