### PR TITLE
Nil check on .RemoteAddr()

### DIFF
--- a/server.go
+++ b/server.go
@@ -127,7 +127,11 @@ func (sf *Server) ServeConn(conn net.Conn) error {
 	}
 
 	// Authenticate the connection
-	authContext, err = sf.authenticate(conn, bufConn, conn.RemoteAddr().String(), mr.Methods)
+	userAddr := ""
+	if conn.RemoteAddr() != nil {
+		userAddr = conn.RemoteAddr().String()
+	}
+	authContext, err = sf.authenticate(conn, bufConn, userAddr, mr.Methods)
 	if err != nil {
 		return fmt.Errorf("failed to authenticate: %w", err)
 	}


### PR DESCRIPTION
In some contexts when using `.ServeConn()` the `net.Conn` interface may have a `nil` `RemoteAddr`. This patch checks for a `nil` `RemoteAddr` before calling `.String()` to avoid a `nil` de-reference. 