### PR TITLE
bugfix: 修复UDP转发功能

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,13 +2,11 @@
 # https://github.com/golangci/golangci/wiki/Configuration
 linters-settings:
   depguard:
-    list-type: blacklist
-    packages:
-      # logging is allowed only by logutils.Log, logrus
-      # is allowed to use only in logutils package
-      - github.com/sirupsen/logrus
-    packages-with-error-message:
-      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
+    rules:
+      main:
+        deny:
+          - pkg: "github.com/sirupsen/logrus"
+            desc: not allowed
   exhaustive:
     default-signifies-exhaustive: false
   gci:
@@ -73,7 +71,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
+#    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -95,13 +93,13 @@ linters:
     - rowserrcheck
     - scopelint
     - staticcheck
-    - structcheck
+#    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
+#    - varcheck
     - whitespace
     - unparam
   #  - interfacer

--- a/handle.go
+++ b/handle.go
@@ -1,7 +1,6 @@
 package socks5
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -23,9 +22,9 @@ type Request struct {
 	statute.Request
 	// AuthContext provided during negotiation
 	AuthContext *AuthContext
-	// LocalAddr of the the network server listen
+	// LocalAddr of the network server listen
 	LocalAddr net.Addr
-	// RemoteAddr of the the network that sent the request
+	// RemoteAddr of the network that sent the request
 	RemoteAddr net.Addr
 	// DestAddr of the actual destination (might be affected by rewrite)
 	DestAddr *statute.AddrSpec
@@ -161,6 +160,8 @@ func (sf *Server) handleBind(_ context.Context, writer io.Writer, _ *Request) er
 }
 
 // handleAssociate is used to handle a connect command
+//
+//nolint:unparam
 func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request *Request) error {
 	// Attempt to connect
 	dial := sf.dial
@@ -213,7 +214,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 			}
 
 			// check src addr whether equal requst.DestAddr
-			srcEqual := ((request.DestAddr.IP.IsUnspecified()) || bytes.Equal(request.DestAddr.IP, srcAddr.IP)) && (request.DestAddr.Port == 0 || request.DestAddr.Port == srcAddr.Port)
+			srcEqual := ((request.DestAddr.IP.IsUnspecified()) || request.DestAddr.IP.Equal(srcAddr.IP)) && (request.DestAddr.Port == 0 || request.DestAddr.Port == srcAddr.Port) //nolint:lll
 			if !srcEqual {
 				continue
 			}
@@ -283,9 +284,8 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 			bindLn.Close()
 			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
 				return nil
-			} else {
-				return err
 			}
+			return err
 		}
 	}
 }

--- a/statute/auth.go
+++ b/statute/auth.go
@@ -39,6 +39,8 @@ func NewUserPassRequest(ver byte, user, pass []byte) UserPassRequest {
 }
 
 // ParseUserPassRequest parse user's password request.
+//
+//nolint:nakedret
 func ParseUserPassRequest(r io.Reader) (nup UserPassRequest, err error) {
 	tmp := []byte{0, 0}
 

--- a/statute/datagram.go
+++ b/statute/datagram.go
@@ -37,6 +37,8 @@ func NewDatagram(destAddr string, data []byte) (p Datagram, err error) {
 }
 
 // ParseDatagram parse to datagram from bytes
+//
+//nolint:nakedret
 func ParseDatagram(b []byte) (da Datagram, err error) {
 	if len(b) < 4+net.IPv4len+2 { // no enough data
 		err = errors.New("datagram to short")


### PR DESCRIPTION
https://github.com/things-go/go-socks5/issues/29 和 https://github.com/things-go/go-socks5/pull/1 中提到，RFC标准中的Associate function逻辑和当前实现的有出入，

https://github.com/things-go/go-socks5/pull/1#issuecomment-680734890 中提到
> 因为RFC文档里面规定UDP Associate请求所携带的地址应当是client欲发送数据的地址+端口，这一个值可以被服务器用来限制来自其余地址的数据包。
你所说的真实UDP地址是在UDP Associate请求协商完成之后，在client向socks5服务器发送的数据必须加上一个特殊的数据包头，包头中携带真实的目标udp地址，服务器解析后决定将client的请求发往何处

但目前实现逻辑恰好是相反的，因此本提交修复了这个问题，使其符合RFC1928标准

目前可以顺利通过 https://github.com/txthinking/testsocks5 和 https://github.com/semigodking/socks5chk 的udp转发测试，同时正确处理了EOF和连接关闭的情况，可以正常退出协程。


