### PR TITLE
use LocalAddr for UDP associate bind address

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -186,7 +186,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 			return net.Dial(net_, addr)
 		}
 	}
-	bindLn, err := net.ListenUDP("udp", nil)
+	bindLn, err := net.ListenUDP("udp", &net.UDPAddr{IP: request.LocalAddr.(*net.TCPAddr).IP, Port: 0})
 	if err != nil {
 		if err := SendReply(writer, statute.RepServerFailure, nil); err != nil {
 			return fmt.Errorf("failed to send reply, %v", err)


### PR DESCRIPTION
In UDP associate, the IP address used for connection from the client should be notified to client (at least, https://github.com/3proxy/3proxy is implemented in this way).
<s>This also fixes IPv6 address ([::]) replied for IPv4 UDP associate request (in bytes, [5, 3, 0, 1, 0, 0, 0, 0, 0, 0]).</s> Sorry this is wrong.