### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CodeQL
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/things-go/go-socks5/security/code-scanning/7](https://github.com/things-go/go-socks5/security/code-scanning/7)

To fix the issue, add an explicit `permissions` block scoped as narrowly as possible. For most CodeQL workflows, only `contents: read` is required, unless results are uploaded or specific write access to PRs is needed (not present in this example). The best place to add this is at the workflow root (top-level), so it applies to all jobs—unless a specific job (like `analyze`) requires additional permissions.

Specifically:
- Add the following block at the top level of `.github/workflows/codeql.yml` after `name: CodeQL`:
  ```yaml
  permissions:
    contents: read
  ```
- This ensures that the `GITHUB_TOKEN` used by all jobs in this workflow is restricted to read-only access to repository contents.

No imports or other supporting code are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
